### PR TITLE
Feature/java saeng/str 11/북마크 추천해요 저장 취소 api 개발

### DIFF
--- a/src/main/java/com/ssg/intern/dev/domain/bookmark/dao/BookmarkRepository.java
+++ b/src/main/java/com/ssg/intern/dev/domain/bookmark/dao/BookmarkRepository.java
@@ -1,0 +1,7 @@
+package com.ssg.intern.dev.domain.bookmark.dao;
+
+import com.ssg.intern.dev.domain.bookmark.entity.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, BookmarkRepositoryCustom {
+}

--- a/src/main/java/com/ssg/intern/dev/domain/bookmark/dao/BookmarkRepositoryCustom.java
+++ b/src/main/java/com/ssg/intern/dev/domain/bookmark/dao/BookmarkRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.ssg.intern.dev.domain.bookmark.dao;
+
+import com.ssg.intern.dev.domain.bookmark.entity.Bookmark;
+
+import java.util.Optional;
+
+public interface BookmarkRepositoryCustom {
+
+    Optional<Bookmark> findBookmarkByFeedAndAccount(final long feedId, final long accountId);
+}

--- a/src/main/java/com/ssg/intern/dev/domain/bookmark/dao/BookmarkRepositoryImpl.java
+++ b/src/main/java/com/ssg/intern/dev/domain/bookmark/dao/BookmarkRepositoryImpl.java
@@ -1,17 +1,14 @@
 package com.ssg.intern.dev.domain.bookmark.dao;
 
-import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ssg.intern.dev.domain.bookmark.entity.Bookmark;
-import com.ssg.intern.dev.domain.bookmark.entity.QBookmark;
-import com.ssg.intern.dev.domain.feed.entity.QFeed;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Optional;
 
-import static com.ssg.intern.dev.domain.bookmark.entity.QBookmark.*;
-import static com.ssg.intern.dev.domain.feed.entity.QFeed.*;
+import static com.ssg.intern.dev.domain.bookmark.entity.QBookmark.bookmark;
+import static com.ssg.intern.dev.domain.feed.entity.QFeed.feed;
 
 @RequiredArgsConstructor
 public class BookmarkRepositoryImpl implements BookmarkRepositoryCustom {

--- a/src/main/java/com/ssg/intern/dev/domain/bookmark/dao/BookmarkRepositoryImpl.java
+++ b/src/main/java/com/ssg/intern/dev/domain/bookmark/dao/BookmarkRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.ssg.intern.dev.domain.bookmark.dao;
+
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ssg.intern.dev.domain.bookmark.entity.Bookmark;
+import com.ssg.intern.dev.domain.bookmark.entity.QBookmark;
+import com.ssg.intern.dev.domain.feed.entity.QFeed;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.ssg.intern.dev.domain.bookmark.entity.QBookmark.*;
+import static com.ssg.intern.dev.domain.feed.entity.QFeed.*;
+
+@RequiredArgsConstructor
+public class BookmarkRepositoryImpl implements BookmarkRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Bookmark> findBookmarkByFeedAndAccount(final long feedId, final long accountId) {
+        return Optional.ofNullable(queryFactory.selectFrom(bookmark)
+                                               .innerJoin(feed).fetchJoin()
+                                               .on(bookmark.feed.id.eq(feed.id))
+                                               .where(eqAccountId(accountId).and(eqFeedId(feedId)))
+                                               .fetchFirst());
+    }
+
+    private BooleanExpression eqFeedId(final long feedId) {
+        return bookmark.feed.id.eq(feedId);
+    }
+
+    private BooleanExpression eqAccountId(final long accountId) {
+        return bookmark.accountId.eq(accountId);
+    }
+}

--- a/src/main/java/com/ssg/intern/dev/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/ssg/intern/dev/domain/bookmark/entity/Bookmark.java
@@ -46,4 +46,8 @@ public class Bookmark extends BaseEntity {
     public void addBookmark() {
         isBookmarked = true;
     }
+
+    public void cancelBookmark() {
+        isBookmarked = false;
+    }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/ssg/intern/dev/domain/bookmark/entity/Bookmark.java
@@ -42,4 +42,8 @@ public class Bookmark extends BaseEntity {
     public static Bookmark of(final Long accountId, final Feed feed, final boolean isBookmarked) {
         return new Bookmark(accountId, feed, isBookmarked);
     }
+
+    public void addBookmark() {
+        isBookmarked = true;
+    }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/bookmark/presentation/BookmarkApi.java
+++ b/src/main/java/com/ssg/intern/dev/domain/bookmark/presentation/BookmarkApi.java
@@ -1,0 +1,24 @@
+package com.ssg.intern.dev.domain.bookmark.presentation;
+
+import com.ssg.intern.dev.domain.bookmark.service.BookmarkCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class BookmarkApi {
+
+    private final BookmarkCommandService bookmarkCommandService;
+
+    @PostMapping("/feeds/{feed-id}/bookmarks")
+    public void plusBookmark(@RequestHeader(HttpHeaders.AUTHORIZATION) long accountId,
+                              @PathVariable("feed-id") long feedId) {
+        bookmarkCommandService.addBookmarkToFeedByFeedId(accountId, feedId);
+    }
+}

--- a/src/main/java/com/ssg/intern/dev/domain/bookmark/presentation/BookmarkApi.java
+++ b/src/main/java/com/ssg/intern/dev/domain/bookmark/presentation/BookmarkApi.java
@@ -19,7 +19,7 @@ public class BookmarkApi {
 
     @PostMapping("/feeds/{feed-id}/bookmarks")
     public void plusBookmark(@RequestHeader(HttpHeaders.AUTHORIZATION) long accountId,
-                              @PathVariable("feed-id") long feedId) {
+                             @PathVariable("feed-id") long feedId) {
         bookmarkCommandService.addBookmarkToFeedByFeedId(accountId, feedId);
     }
 

--- a/src/main/java/com/ssg/intern/dev/domain/bookmark/presentation/BookmarkApi.java
+++ b/src/main/java/com/ssg/intern/dev/domain/bookmark/presentation/BookmarkApi.java
@@ -3,6 +3,7 @@ package com.ssg.intern.dev.domain.bookmark.presentation;
 import com.ssg.intern.dev.domain.bookmark.service.BookmarkCommandService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -20,5 +21,11 @@ public class BookmarkApi {
     public void plusBookmark(@RequestHeader(HttpHeaders.AUTHORIZATION) long accountId,
                               @PathVariable("feed-id") long feedId) {
         bookmarkCommandService.addBookmarkToFeedByFeedId(accountId, feedId);
+    }
+
+    @DeleteMapping("/feeds/{feed-id}/bookmarks")
+    public void minusBookmark(@RequestHeader(HttpHeaders.AUTHORIZATION) long accountId,
+                              @PathVariable("feed-id") long feedId) {
+        bookmarkCommandService.cancelBookmarkToFeedByFeedId(accountId, feedId);
     }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/bookmark/service/BookmarkCommandService.java
+++ b/src/main/java/com/ssg/intern/dev/domain/bookmark/service/BookmarkCommandService.java
@@ -41,4 +41,15 @@ public class BookmarkCommandService {
                         }
                 );
     }
+
+    public void cancelBookmarkToFeedByFeedId(final long accountId, final long feedId) {
+
+        bookmarkRepository.findBookmarkByFeedAndAccount(feedId, accountId)
+                .ifPresent(
+                        (bookmark -> {
+                            bookmark.cancelBookmark();
+                            bookmark.getFeed().decreaseBookmark();
+                        })
+                );
+    }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/bookmark/service/BookmarkCommandService.java
+++ b/src/main/java/com/ssg/intern/dev/domain/bookmark/service/BookmarkCommandService.java
@@ -26,8 +26,11 @@ public class BookmarkCommandService {
 
                             final Feed savedFeed = bookmark.getFeed();
 
-                            savedFeed.increaseBookmark();
-                            bookmark.addBookmark();
+                            if (!bookmark.isBookmarked()) {
+                                savedFeed.increaseBookmark();
+                                bookmark.addBookmark();
+                            }
+
                         }),
 
                         () -> {
@@ -47,8 +50,11 @@ public class BookmarkCommandService {
         bookmarkRepository.findBookmarkByFeedAndAccount(feedId, accountId)
                 .ifPresent(
                         (bookmark -> {
-                            bookmark.cancelBookmark();
-                            bookmark.getFeed().decreaseBookmark();
+
+                            if (bookmark.isBookmarked()) {
+                                bookmark.cancelBookmark();
+                                bookmark.getFeed().decreaseBookmark();
+                            }
                         })
                 );
     }

--- a/src/main/java/com/ssg/intern/dev/domain/bookmark/service/BookmarkCommandService.java
+++ b/src/main/java/com/ssg/intern/dev/domain/bookmark/service/BookmarkCommandService.java
@@ -21,41 +21,41 @@ public class BookmarkCommandService {
     public void addBookmarkToFeedByFeedId(final long accountId, final long feedId) {
 
         bookmarkRepository.findBookmarkByFeedAndAccount(feedId, accountId)
-                .ifPresentOrElse(
-                        (bookmark -> {
+                          .ifPresentOrElse(
+                                  (bookmark -> {
 
-                            final Feed savedFeed = bookmark.getFeed();
+                                      final Feed savedFeed = bookmark.getFeed();
 
-                            if (!bookmark.isBookmarked()) {
-                                savedFeed.increaseBookmark();
-                                bookmark.addBookmark();
-                            }
+                                      if (!bookmark.isBookmarked()) {
+                                          savedFeed.increaseBookmark();
+                                          bookmark.addBookmark();
+                                      }
 
-                        }),
+                                  }),
 
-                        () -> {
-                            final Feed savedFeed = feedRepository.findById(feedId)
-                                                                 .orElseThrow(EntityNotFoundException::new);
+                                  () -> {
+                                      final Feed savedFeed = feedRepository.findById(feedId)
+                                                                           .orElseThrow(EntityNotFoundException::new);
 
-                            final Bookmark bookmark = Bookmark.of(accountId, savedFeed, true);
+                                      final Bookmark bookmark = Bookmark.of(accountId, savedFeed, true);
 
-                            bookmarkRepository.save(bookmark);
-                            savedFeed.increaseBookmark();
-                        }
-                );
+                                      bookmarkRepository.save(bookmark);
+                                      savedFeed.increaseBookmark();
+                                  }
+                          );
     }
 
     public void cancelBookmarkToFeedByFeedId(final long accountId, final long feedId) {
 
         bookmarkRepository.findBookmarkByFeedAndAccount(feedId, accountId)
-                .ifPresent(
-                        (bookmark -> {
+                          .ifPresent(
+                                  (bookmark -> {
 
-                            if (bookmark.isBookmarked()) {
-                                bookmark.cancelBookmark();
-                                bookmark.getFeed().decreaseBookmark();
-                            }
-                        })
-                );
+                                      if (bookmark.isBookmarked()) {
+                                          bookmark.cancelBookmark();
+                                          bookmark.getFeed().decreaseBookmark();
+                                      }
+                                  })
+                          );
     }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/bookmark/service/BookmarkCommandService.java
+++ b/src/main/java/com/ssg/intern/dev/domain/bookmark/service/BookmarkCommandService.java
@@ -1,0 +1,44 @@
+package com.ssg.intern.dev.domain.bookmark.service;
+
+import com.ssg.intern.dev.domain.bookmark.dao.BookmarkRepository;
+import com.ssg.intern.dev.domain.bookmark.entity.Bookmark;
+import com.ssg.intern.dev.domain.feed.dao.FeedRepository;
+import com.ssg.intern.dev.domain.feed.entity.Feed;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BookmarkCommandService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final FeedRepository feedRepository;
+
+    public void addBookmarkToFeedByFeedId(final long accountId, final long feedId) {
+
+        bookmarkRepository.findBookmarkByFeedAndAccount(feedId, accountId)
+                .ifPresentOrElse(
+                        (bookmark -> {
+
+                            final Feed savedFeed = bookmark.getFeed();
+
+                            savedFeed.increaseBookmark();
+                            bookmark.addBookmark();
+                        }),
+
+                        () -> {
+                            final Feed savedFeed = feedRepository.findById(feedId)
+                                                                 .orElseThrow(EntityNotFoundException::new);
+
+                            final Bookmark bookmark = Bookmark.of(accountId, savedFeed, true);
+
+                            bookmarkRepository.save(bookmark);
+                            savedFeed.increaseBookmark();
+                        }
+                );
+    }
+}

--- a/src/main/java/com/ssg/intern/dev/domain/feed/dao/FeedRepositoryCustom.java
+++ b/src/main/java/com/ssg/intern/dev/domain/feed/dao/FeedRepositoryCustom.java
@@ -1,13 +1,10 @@
 package com.ssg.intern.dev.domain.feed.dao;
 
 import com.ssg.intern.dev.domain.feed.entity.Feed;
-import com.ssg.intern.dev.global.SortingCondition;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
-
 public interface FeedRepositoryCustom {
 
-    public Page<Feed> findAllFeeds(Pageable pageable);
+    Page<Feed> findAllFeeds(Pageable pageable);
 }

--- a/src/main/java/com/ssg/intern/dev/domain/feed/dao/FeedRepositoryCustomImpl.java
+++ b/src/main/java/com/ssg/intern/dev/domain/feed/dao/FeedRepositoryCustomImpl.java
@@ -2,7 +2,6 @@ package com.ssg.intern.dev.domain.feed.dao;
 
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ssg.intern.dev.domain.feed.entity.Feed;
 import com.ssg.intern.dev.global.SortingCondition;
@@ -12,12 +11,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
-import static com.ssg.intern.dev.domain.comment.entity.QComment.*;
-import static com.ssg.intern.dev.domain.feed.entity.QFeed.*;
+import static com.ssg.intern.dev.domain.comment.entity.QComment.comment;
+import static com.ssg.intern.dev.domain.feed.entity.QFeed.feed;
 
 @RequiredArgsConstructor
 public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {

--- a/src/main/java/com/ssg/intern/dev/domain/feed/entity/Feed.java
+++ b/src/main/java/com/ssg/intern/dev/domain/feed/entity/Feed.java
@@ -55,4 +55,8 @@ public class Feed extends BaseEntity {
     public void decreaseRecommend() {
         recommendCount--;
     }
+
+    public void increaseBookmark() {
+        bookmarkCount++;
+    }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/feed/entity/Feed.java
+++ b/src/main/java/com/ssg/intern/dev/domain/feed/entity/Feed.java
@@ -59,4 +59,8 @@ public class Feed extends BaseEntity {
     public void increaseBookmark() {
         bookmarkCount++;
     }
+
+    public void decreaseBookmark() {
+        bookmarkCount--;
+    }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/feed/entity/Feed.java
+++ b/src/main/java/com/ssg/intern/dev/domain/feed/entity/Feed.java
@@ -29,10 +29,10 @@ public class Feed extends BaseEntity {
     private Long specialReviewId;
 
     @Column(nullable = false)
-    private Long bookmarkCount;
+    private long bookmarkCount;
 
     @Column(nullable = false)
-    private Long recommendCount;
+    private long recommendCount;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "feed")
     private List<Comment> comments = new ArrayList<>();
@@ -46,5 +46,9 @@ public class Feed extends BaseEntity {
 
     public static Feed from(Long reviewId) {
         return new Feed(reviewId);
+    }
+
+    public void increaseRecommend() {
+        recommendCount++;
     }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/feed/entity/Feed.java
+++ b/src/main/java/com/ssg/intern/dev/domain/feed/entity/Feed.java
@@ -35,7 +35,7 @@ public class Feed extends BaseEntity {
     private long recommendCount;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "feed")
-    private List<Comment> comments = new ArrayList<>();
+    private final List<Comment> comments = new ArrayList<>();
 
     @Column(columnDefinition = "TINYINT(1)")
     private boolean isCommentBlocked;

--- a/src/main/java/com/ssg/intern/dev/domain/feed/entity/Feed.java
+++ b/src/main/java/com/ssg/intern/dev/domain/feed/entity/Feed.java
@@ -51,4 +51,8 @@ public class Feed extends BaseEntity {
     public void increaseRecommend() {
         recommendCount++;
     }
+
+    public void decreaseRecommend() {
+        recommendCount--;
+    }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepository.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepository.java
@@ -1,0 +1,7 @@
+package com.ssg.intern.dev.domain.recommend.dao;
+
+import com.ssg.intern.dev.domain.recommend.entity.Recommend;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecommendRepository extends JpaRepository<Recommend, Long> {
+}

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepository.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface RecommendRepository extends JpaRepository<Recommend, Long> {
+public interface RecommendRepository extends JpaRepository<Recommend, Long>, RecommendRepositoryCustom {
 
     @Override
     @Query("select r from Recommend r inner join fetch r.feed where r.id=:id")

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepository.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepository.java
@@ -2,6 +2,14 @@ package com.ssg.intern.dev.domain.recommend.dao;
 
 import com.ssg.intern.dev.domain.recommend.entity.Recommend;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface RecommendRepository extends JpaRepository<Recommend, Long> {
+
+    @Override
+    @Query("select r from Recommend r inner join fetch r.feed where r.id=:id")
+    Optional<Recommend> findById(@Param("id") Long recommendId);
 }

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepository.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepository.java
@@ -2,14 +2,7 @@ package com.ssg.intern.dev.domain.recommend.dao;
 
 import com.ssg.intern.dev.domain.recommend.entity.Recommend;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.Optional;
 
 public interface RecommendRepository extends JpaRepository<Recommend, Long>, RecommendRepositoryCustom {
 
-    @Override
-    @Query("select r from Recommend r inner join fetch r.feed where r.id=:id")
-    Optional<Recommend> findById(@Param("id") Long recommendId);
 }

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepositoryCustom.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.ssg.intern.dev.domain.recommend.dao;
+
+import com.ssg.intern.dev.domain.recommend.entity.Recommend;
+
+import java.util.Optional;
+
+public interface RecommendRepositoryCustom {
+
+    public Optional<Recommend> findRecommendByFeedAndAccount(long feedId, long accountId);
+}

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepositoryCustom.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepositoryCustom.java
@@ -6,5 +6,5 @@ import java.util.Optional;
 
 public interface RecommendRepositoryCustom {
 
-    public Optional<Recommend> findRecommendByFeedAndAccount(long feedId, long accountId);
+    Optional<Recommend> findRecommendByFeedAndAccount(long feedId, long accountId);
 }

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepositoryImpl.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepositoryImpl.java
@@ -2,15 +2,13 @@ package com.ssg.intern.dev.domain.recommend.dao;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.ssg.intern.dev.domain.feed.entity.QFeed;
-import com.ssg.intern.dev.domain.recommend.entity.QRecommend;
 import com.ssg.intern.dev.domain.recommend.entity.Recommend;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Optional;
 
-import static com.ssg.intern.dev.domain.feed.entity.QFeed.*;
-import static com.ssg.intern.dev.domain.recommend.entity.QRecommend.*;
+import static com.ssg.intern.dev.domain.feed.entity.QFeed.feed;
+import static com.ssg.intern.dev.domain.recommend.entity.QRecommend.recommend;
 
 @RequiredArgsConstructor
 public class RecommendRepositoryImpl implements RecommendRepositoryCustom {

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepositoryImpl.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.ssg.intern.dev.domain.recommend.dao;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ssg.intern.dev.domain.feed.entity.QFeed;
+import com.ssg.intern.dev.domain.recommend.entity.QRecommend;
+import com.ssg.intern.dev.domain.recommend.entity.Recommend;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.ssg.intern.dev.domain.feed.entity.QFeed.*;
+import static com.ssg.intern.dev.domain.recommend.entity.QRecommend.*;
+
+@RequiredArgsConstructor
+public class RecommendRepositoryImpl implements RecommendRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Recommend> findRecommendByFeedAndAccount(final long feedId, final long accountId) {
+        return Optional.ofNullable(queryFactory.selectFrom(recommend)
+                                               .innerJoin(feed).fetchJoin()
+                                               .on(recommend.feed.id.eq(feed.id))
+                                               .where(eqFeedId(feedId).and(eqAccountId(accountId)))
+                                               .fetchFirst());
+    }
+
+    private BooleanExpression eqAccountId(long accountId) {
+        return recommend.accountId.eq(accountId);
+    }
+
+    private BooleanExpression eqFeedId(long feedId) {
+        return feed.id.eq(feedId);
+    }
+}

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepositoryImpl.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepositoryImpl.java
@@ -31,6 +31,6 @@ public class RecommendRepositoryImpl implements RecommendRepositoryCustom {
     }
 
     private BooleanExpression eqFeedId(long feedId) {
-        return feed.id.eq(feedId);
+        return recommend.feed.id.eq(feedId);
     }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/entity/Recommend.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/entity/Recommend.java
@@ -46,4 +46,8 @@ public class Recommend extends BaseEntity {
     public void addRecommend() {
         isRecommended = true;
     }
+
+    public void cancelRecommend() {
+        isRecommended = false;
+    }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/entity/Recommend.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/entity/Recommend.java
@@ -42,4 +42,8 @@ public class Recommend extends BaseEntity {
     public static Recommend of(final Long accountId, final boolean isRecommended, final Feed feed) {
         return new Recommend(accountId, isRecommended, feed);
     }
+
+    public void addRecommend() {
+        isRecommended = true;
+    }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/presentation/RecommendApi.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/presentation/RecommendApi.java
@@ -3,6 +3,7 @@ package com.ssg.intern.dev.domain.recommend.presentation;
 import com.ssg.intern.dev.domain.recommend.service.RecommendCommandService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -23,5 +24,12 @@ public class RecommendApi {
                               @PathVariable("feed-id") long feedId,
                               @PathVariable(value = "recommend-id", required = false) Optional<Long> recommendId) {
         return recommendCommandService.addRecommendToFeedByFeedId(accountId, feedId, recommendId);
+    }
+
+    @DeleteMapping("/feeds/{feed-id}/recommends/{recommend-id}")
+    public long minusRecommend(@RequestHeader(HttpHeaders.AUTHORIZATION) long accountId,
+                              @PathVariable("feed-id") long feedId,
+                              @PathVariable("recommend-id") long recommendId) {
+        return recommendCommandService.cancelRecommendToFeedByFeedId(accountId, feedId, recommendId);
     }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/presentation/RecommendApi.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/presentation/RecommendApi.java
@@ -25,10 +25,9 @@ public class RecommendApi {
         recommendCommandService.addRecommendToFeedByFeedId(accountId, feedId);
     }
 
-    @DeleteMapping("/feeds/{feed-id}/recommends/{recommend-id}")
-    public long minusRecommend(@RequestHeader(HttpHeaders.AUTHORIZATION) long accountId,
-                              @PathVariable("feed-id") long feedId,
-                              @PathVariable("recommend-id") long recommendId) {
-        return recommendCommandService.cancelRecommendToFeedByFeedId(accountId, feedId, recommendId);
+    @DeleteMapping("/feeds/{feed-id}/recommends")
+    public void minusRecommend(@RequestHeader(HttpHeaders.AUTHORIZATION) long accountId,
+                              @PathVariable("feed-id") long feedId) {
+        recommendCommandService.cancelRecommendToFeedByFeedId(accountId, feedId);
     }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/presentation/RecommendApi.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/presentation/RecommendApi.java
@@ -10,8 +10,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Optional;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -19,7 +17,7 @@ public class RecommendApi {
 
     private final RecommendCommandService recommendCommandService;
 
-    @PostMapping( "/feeds/{feed-id}/recommends")
+    @PostMapping("/feeds/{feed-id}/recommends")
     public void plusRecommend(@RequestHeader(HttpHeaders.AUTHORIZATION) long accountId,
                               @PathVariable("feed-id") long feedId) {
         recommendCommandService.addRecommendToFeedByFeedId(accountId, feedId);
@@ -27,7 +25,7 @@ public class RecommendApi {
 
     @DeleteMapping("/feeds/{feed-id}/recommends")
     public void minusRecommend(@RequestHeader(HttpHeaders.AUTHORIZATION) long accountId,
-                              @PathVariable("feed-id") long feedId) {
+                               @PathVariable("feed-id") long feedId) {
         recommendCommandService.cancelRecommendToFeedByFeedId(accountId, feedId);
     }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/presentation/RecommendApi.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/presentation/RecommendApi.java
@@ -19,11 +19,10 @@ public class RecommendApi {
 
     private final RecommendCommandService recommendCommandService;
 
-    @PostMapping(value = {"/feeds/{feed-id}/recommends/{recommend-id}", "/feeds/{feed-id}/recommends"})
-    public long plusRecommend(@RequestHeader(HttpHeaders.AUTHORIZATION) long accountId,
-                              @PathVariable("feed-id") long feedId,
-                              @PathVariable(value = "recommend-id", required = false) Optional<Long> recommendId) {
-        return recommendCommandService.addRecommendToFeedByFeedId(accountId, feedId, recommendId);
+    @PostMapping( "/feeds/{feed-id}/recommends")
+    public void plusRecommend(@RequestHeader(HttpHeaders.AUTHORIZATION) long accountId,
+                              @PathVariable("feed-id") long feedId) {
+        recommendCommandService.addRecommendToFeedByFeedId(accountId, feedId);
     }
 
     @DeleteMapping("/feeds/{feed-id}/recommends/{recommend-id}")

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/presentation/RecommendApi.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/presentation/RecommendApi.java
@@ -1,0 +1,27 @@
+package com.ssg.intern.dev.domain.recommend.presentation;
+
+import com.ssg.intern.dev.domain.recommend.service.RecommendCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class RecommendApi {
+
+    private final RecommendCommandService recommendCommandService;
+
+    @PostMapping(value = {"/feeds/{feed-id}/recommends/{recommend-id}", "/feeds/{feed-id}/recommends"})
+    public long plusRecommend(@RequestHeader(HttpHeaders.AUTHORIZATION) long accountId,
+                              @PathVariable("feed-id") long feedId,
+                              @PathVariable(value = "recommend-id", required = false) Optional<Long> recommendId) {
+        return recommendCommandService.addRecommendToFeedByFeedId(accountId, feedId, recommendId);
+    }
+}

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandService.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandService.java
@@ -1,0 +1,47 @@
+package com.ssg.intern.dev.domain.recommend.service;
+
+import com.ssg.intern.dev.domain.feed.dao.FeedRepository;
+import com.ssg.intern.dev.domain.feed.entity.Feed;
+import com.ssg.intern.dev.domain.recommend.dao.RecommendRepository;
+import com.ssg.intern.dev.domain.recommend.entity.Recommend;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RecommendCommandService {
+
+    private final RecommendRepository recommendRepository;
+    private final FeedRepository feedRepository;
+
+    public long addRecommendToFeedByFeedId(final long accountId, final long feedId,
+                                           final Optional<Long> recommendId) {
+
+        final Feed feed = feedRepository.findById(feedId)
+                                        .orElseThrow(EntityNotFoundException::new);
+
+        feed.increaseRecommend();
+
+        recommendId.ifPresentOrElse(
+                (id) -> {
+                    final Recommend savedRecommend = recommendRepository.findById(id)
+                                                                        .orElseThrow(EntityNotFoundException::new);
+
+                    savedRecommend.addRecommend();
+                },
+
+                () -> {
+                    final Recommend recommend = Recommend.of(accountId, true, feed);
+
+                    recommendRepository.save(recommend);
+                }
+        );
+
+        return feed.getRecommendCount();
+    }
+}

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandService.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandService.java
@@ -43,16 +43,14 @@ public class RecommendCommandService {
                            );
     }
 
-    public long cancelRecommendToFeedByFeedId(final long accountId, final long feedId, final long recommendId) {
-        final Recommend recommend = recommendRepository.findById(recommendId)
-                                                       .orElseThrow(EntityNotFoundException::new);
+    public void cancelRecommendToFeedByFeedId(final long accountId, final long feedId) {
 
-        final Feed feed = recommend.getFeed();
-
-        feed.decreaseRecommend();
-
-        recommend.cancelRecommend();
-
-        return feed.getRecommendCount();
+        recommendRepository.findRecommendByFeedAndAccount(feedId, accountId)
+                .ifPresent(
+                        (recommend -> {
+                            recommend.cancelRecommend();
+                            recommend.getFeed().decreaseRecommend();
+                        })
+                );
     }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandService.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandService.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -49,14 +48,14 @@ public class RecommendCommandService {
     public void cancelRecommendToFeedByFeedId(final long accountId, final long feedId) {
 
         recommendRepository.findRecommendByFeedAndAccount(feedId, accountId)
-                .ifPresent(
-                        (recommend -> {
+                           .ifPresent(
+                                   (recommend -> {
 
-                            if (recommend.isRecommended()) {
-                                recommend.cancelRecommend();
-                                recommend.getFeed().decreaseRecommend();
-                            }
-                        })
-                );
+                                       if (recommend.isRecommended()) {
+                                           recommend.cancelRecommend();
+                                           recommend.getFeed().decreaseRecommend();
+                                       }
+                                   })
+                           );
     }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandService.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandService.java
@@ -44,4 +44,17 @@ public class RecommendCommandService {
 
         return feed.getRecommendCount();
     }
+
+    public long cancelRecommendToFeedByFeedId(final long accountId, final long feedId, final long recommendId) {
+        final Recommend recommend = recommendRepository.findById(recommendId)
+                                                       .orElseThrow(EntityNotFoundException::new);
+
+        final Feed feed = recommend.getFeed();
+
+        feed.decreaseRecommend();
+
+        recommend.cancelRecommend();
+
+        return feed.getRecommendCount();
+    }
 }

--- a/src/main/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandService.java
+++ b/src/main/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandService.java
@@ -27,8 +27,11 @@ public class RecommendCommandService {
 
                                        final Feed savedFeed = recommend.getFeed();
 
-                                       savedFeed.increaseRecommend();
-                                       recommend.addRecommend();
+                                       if (!recommend.isRecommended()) {
+                                           savedFeed.increaseRecommend();
+                                           recommend.addRecommend();
+                                       }
+
                                    }),
 
                                    () -> {
@@ -48,8 +51,11 @@ public class RecommendCommandService {
         recommendRepository.findRecommendByFeedAndAccount(feedId, accountId)
                 .ifPresent(
                         (recommend -> {
-                            recommend.cancelRecommend();
-                            recommend.getFeed().decreaseRecommend();
+
+                            if (recommend.isRecommended()) {
+                                recommend.cancelRecommend();
+                                recommend.getFeed().decreaseRecommend();
+                            }
                         })
                 );
     }

--- a/src/test/java/com/ssg/intern/dev/domain/bookmark/service/BookmarkCommandServiceTest.java
+++ b/src/test/java/com/ssg/intern/dev/domain/bookmark/service/BookmarkCommandServiceTest.java
@@ -4,8 +4,6 @@ import com.ssg.intern.dev.domain.bookmark.dao.BookmarkRepository;
 import com.ssg.intern.dev.domain.bookmark.entity.Bookmark;
 import com.ssg.intern.dev.domain.feed.dao.FeedRepository;
 import com.ssg.intern.dev.domain.feed.entity.Feed;
-import com.ssg.intern.dev.domain.recommend.dao.RecommendRepository;
-import com.ssg.intern.dev.domain.recommend.entity.Recommend;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -73,5 +71,29 @@ class BookmarkCommandServiceTest {
         //then
         assertEquals(feed.getBookmarkCount(), 1);
         verify(bookmarkRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("cancelBookmarkToFeedByFeedId() : feed에 북마크를 취소할 수 있습니다.")
+    void test_cancelBookmarkToFeedByFeedId() {
+        //given
+        final Feed feed = Feed.from(1L);
+        final Bookmark bookmark = Bookmark.of(1L, feed, true);
+
+        feed.increaseBookmark();
+        feed.increaseBookmark();
+        feed.increaseBookmark();
+
+        //when
+        when(bookmarkRepository.findBookmarkByFeedAndAccount(anyLong(), anyLong()))
+                .thenReturn(Optional.of(bookmark));
+
+        bookmarkCommandService.cancelBookmarkToFeedByFeedId(1L, 1L);
+
+        //then
+        assertAll(
+                () -> assertEquals(feed.getBookmarkCount(), 2),
+                () -> assertFalse(bookmark.isBookmarked())
+        );
     }
 }

--- a/src/test/java/com/ssg/intern/dev/domain/bookmark/service/BookmarkCommandServiceTest.java
+++ b/src/test/java/com/ssg/intern/dev/domain/bookmark/service/BookmarkCommandServiceTest.java
@@ -1,0 +1,77 @@
+package com.ssg.intern.dev.domain.bookmark.service;
+
+import com.ssg.intern.dev.domain.bookmark.dao.BookmarkRepository;
+import com.ssg.intern.dev.domain.bookmark.entity.Bookmark;
+import com.ssg.intern.dev.domain.feed.dao.FeedRepository;
+import com.ssg.intern.dev.domain.feed.entity.Feed;
+import com.ssg.intern.dev.domain.recommend.dao.RecommendRepository;
+import com.ssg.intern.dev.domain.recommend.entity.Recommend;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+@DisplayName("BookmarkCommandService Unit Test")
+class BookmarkCommandServiceTest {
+
+    BookmarkCommandService bookmarkCommandService;
+
+    FeedRepository feedRepository;
+
+    BookmarkRepository bookmarkRepository;
+
+    @BeforeEach
+    void init() {
+        bookmarkRepository = mock(BookmarkRepository.class);
+        feedRepository = mock(FeedRepository.class);
+
+        bookmarkCommandService = new BookmarkCommandService(bookmarkRepository, feedRepository);
+    }
+
+    @Test
+    @DisplayName("addBookmarkToFeedByFeedId() : 적어도 한번 북마크 취소를 누른 feed에서 다시 북마크를 누를 수 있습니다.")
+    void test_addBookmarkToFeedByFeedId_atLeastOnceBookmark() {
+        //given
+        final Feed feed = Feed.from(1L);
+        final Bookmark bookmark = Bookmark.of(1L, feed, false);
+
+        //when
+        when(bookmarkRepository.findBookmarkByFeedAndAccount(anyLong(), anyLong()))
+                .thenReturn(Optional.of(bookmark));
+
+        bookmarkCommandService.addBookmarkToFeedByFeedId(1L, 1L);
+
+        //then
+        assertAll(
+                () -> assertEquals(feed.getBookmarkCount(), 1),
+                () -> assertTrue(bookmark.isBookmarked())
+        );
+    }
+
+    @Test
+    @DisplayName("addBookmarkToFeedByFeedId() : feed에 북마크를 누를 수 있습니다.")
+    void test_addBookmarkToFeedByFeedId_firstRecommend() {
+        //given
+        final Feed feed = Feed.from(1L);
+
+        //when
+        when(bookmarkRepository.findBookmarkByFeedAndAccount(anyLong(), anyLong()))
+                .thenReturn(Optional.empty());
+
+        when(feedRepository.findById(anyLong()))
+                .thenReturn(Optional.of(feed));
+
+        bookmarkCommandService.addBookmarkToFeedByFeedId(1L, 1L);
+
+        //then
+        assertEquals(feed.getBookmarkCount(), 1);
+        verify(bookmarkRepository, times(1)).save(any());
+    }
+}

--- a/src/test/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepositoryImplTest.java
+++ b/src/test/java/com/ssg/intern/dev/domain/recommend/dao/RecommendRepositoryImplTest.java
@@ -1,0 +1,76 @@
+package com.ssg.intern.dev.domain.recommend.dao;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ssg.intern.dev.domain.feed.dao.FeedRepository;
+import com.ssg.intern.dev.domain.feed.entity.Feed;
+import com.ssg.intern.dev.domain.recommend.entity.QRecommend;
+import com.ssg.intern.dev.domain.recommend.entity.Recommend;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static com.ssg.intern.dev.domain.feed.entity.QFeed.feed;
+import static com.ssg.intern.dev.domain.recommend.entity.QRecommend.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@DisplayName("RecommendRepository Querydsl Integration Test")
+class RecommendRepositoryImplTest {
+
+    @Autowired
+    JPAQueryFactory queryFactory;
+
+    @Autowired
+    RecommendRepository recommendRepository;
+
+    @Autowired
+    FeedRepository feedRepository;
+
+    @Test
+    @DisplayName("querydsl를 통해 존재하는 Recommend를 조회할 수 있다.")
+    void test_findRecommendByFeedAndAccount_existedRecommend() {
+        //given
+        long feedId = 1L;
+        long accountId = 1L;
+
+        final Feed savedFeed = feedRepository.findById(feedId).get();
+        final Recommend recommend = recommendRepository.save(Recommend.of(1L, true, savedFeed));
+
+        //when
+        final Optional<Recommend> savedRecommend = Optional.ofNullable(queryFactory.selectFrom(QRecommend.recommend)
+                                                                                   .innerJoin(feed).fetchJoin()
+                                                                                   .on(QRecommend.recommend.feed.id.eq(feed.id))
+                                                                                   .where(feed.id.eq(feedId)
+                                                                                                 .and(QRecommend.recommend.accountId.eq(
+                                                                                                         accountId)))
+                                                                                   .fetchFirst());
+        //then
+        assertAll(
+                () -> assertTrue(savedRecommend.isPresent()),
+                () -> assertEquals(savedRecommend.get().getId(), recommend.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("querydsl를 통해 Recommend가 존재하지 않는 것을 알 수 있다.")
+    void test_findRecommendByFeedAndAccount_notExistedRecommend() {
+        //given
+        long feedId = 1L;
+        long accountId = 1L;
+
+        //when
+        final Optional<Recommend> savedRecommend = Optional.ofNullable(queryFactory.selectFrom(recommend)
+                                                                                   .innerJoin(feed).fetchJoin()
+                                                                                   .on(recommend.feed.id.eq(feed.id))
+                                                                                   .where(feed.id.eq(feedId)
+                                                                                                 .and(recommend.accountId.eq(
+                                                                                                         accountId)))
+                                                                                   .fetchFirst());
+        //then
+        assertFalse(savedRecommend.isPresent());
+    }
+}

--- a/src/test/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandServiceTest.java
+++ b/src/test/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandServiceTest.java
@@ -1,0 +1,78 @@
+package com.ssg.intern.dev.domain.recommend.service;
+
+import com.ssg.intern.dev.domain.feed.dao.FeedRepository;
+import com.ssg.intern.dev.domain.feed.entity.Feed;
+import com.ssg.intern.dev.domain.recommend.dao.RecommendRepository;
+import com.ssg.intern.dev.domain.recommend.entity.Recommend;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("RecommendCommandService Unit Test")
+class RecommendCommandServiceTest {
+
+    RecommendCommandService recommendCommandService;
+
+    FeedRepository feedRepository;
+
+    RecommendRepository recommendRepository;
+
+    @BeforeEach
+    void init() {
+        recommendRepository = mock(RecommendRepository.class);
+        feedRepository = mock(FeedRepository.class);
+
+        recommendCommandService = new RecommendCommandService(recommendRepository, feedRepository);
+    }
+
+    @Test
+    @DisplayName("addRecommendToFeedByFeedId() : 적어도 한번 추천해요 취소를 누른 feed에서 다시 추천해요를 누를 수 있습니다.")
+    void test_addRecommendToFeedByFeedId_atLeastOnceRecommend() {
+        //given
+        final Feed feed = Feed.from(1L);
+        final Recommend recommend = Recommend.of(1L, false, feed);
+
+        //when
+        when(feedRepository.findById(anyLong()))
+                .thenReturn(Optional.of(feed));
+
+        when(recommendRepository.findById(anyLong()))
+                .thenReturn(Optional.of(recommend));
+
+        final long recommendCount = recommendCommandService.
+                addRecommendToFeedByFeedId(1L, 1L, Optional.of(1L));
+
+        //then
+        assertAll(
+                () -> assertEquals(recommendCount, 1),
+                () -> assertTrue(recommend.isRecommended())
+        );
+    }
+
+    @Test
+    @DisplayName("addRecommendToFeedByFeedId() : feed에 추천해요를 누를 수 있습니다.")
+    void test_addRecommendToFeedByFeedId_firstRecommend() {
+        //given
+        final Feed feed = Feed.from(1L);
+
+        //when
+        when(feedRepository.findById(anyLong()))
+                .thenReturn(Optional.of(feed));
+
+        when(recommendRepository.findById(anyLong()))
+                .thenReturn(Optional.empty());
+
+        final long recommendCount = recommendCommandService.
+                addRecommendToFeedByFeedId(1L, 1L, Optional.empty());
+
+        //then
+        assertEquals(recommendCount, 1);
+    }
+}

--- a/src/test/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandServiceTest.java
+++ b/src/test/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandServiceTest.java
@@ -83,18 +83,14 @@ class RecommendCommandServiceTest {
         feed.increaseRecommend();
 
         //when
-        when(feedRepository.findById(anyLong()))
-                .thenReturn(Optional.of(feed));
-
-        when(recommendRepository.findById(anyLong()))
+        when(recommendRepository.findRecommendByFeedAndAccount(anyLong(), anyLong()))
                 .thenReturn(Optional.of(recommend));
 
-        final long recommendCount = recommendCommandService.
-                cancelRecommendToFeedByFeedId(1L, 1L, 1L);
+        recommendCommandService.cancelRecommendToFeedByFeedId(1L, 1L);
 
         //then
         assertAll(
-                () -> assertEquals(recommendCount, 2),
+                () -> assertEquals(feed.getRecommendCount(), 2),
                 () -> assertFalse(recommend.isRecommended())
         );
     }

--- a/src/test/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandServiceTest.java
+++ b/src/test/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandServiceTest.java
@@ -12,8 +12,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @DisplayName("RecommendCommandService Unit Test")
 class RecommendCommandServiceTest {
@@ -40,18 +39,14 @@ class RecommendCommandServiceTest {
         final Recommend recommend = Recommend.of(1L, false, feed);
 
         //when
-        when(feedRepository.findById(anyLong()))
-                .thenReturn(Optional.of(feed));
-
-        when(recommendRepository.findById(anyLong()))
+        when(recommendRepository.findRecommendByFeedAndAccount(anyLong(), anyLong()))
                 .thenReturn(Optional.of(recommend));
 
-        final long recommendCount = recommendCommandService.
-                addRecommendToFeedByFeedId(1L, 1L, Optional.of(1L));
+        recommendCommandService.addRecommendToFeedByFeedId(1L, 1L);
 
         //then
         assertAll(
-                () -> assertEquals(recommendCount, 1),
+                () -> assertEquals(feed.getRecommendCount(), 1),
                 () -> assertTrue(recommend.isRecommended())
         );
     }
@@ -66,14 +61,14 @@ class RecommendCommandServiceTest {
         when(feedRepository.findById(anyLong()))
                 .thenReturn(Optional.of(feed));
 
-        when(recommendRepository.findById(anyLong()))
+        when(recommendRepository.findRecommendByFeedAndAccount(anyLong(), anyLong()))
                 .thenReturn(Optional.empty());
 
-        final long recommendCount = recommendCommandService.
-                addRecommendToFeedByFeedId(1L, 1L, Optional.empty());
+        recommendCommandService.addRecommendToFeedByFeedId(1L, 1L);
 
         //then
-        assertEquals(recommendCount, 1);
+        assertEquals(feed.getRecommendCount(), 1);
+        verify(recommendRepository, times(1)).save(any());
     }
 
     @Test

--- a/src/test/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandServiceTest.java
+++ b/src/test/java/com/ssg/intern/dev/domain/recommend/service/RecommendCommandServiceTest.java
@@ -75,4 +75,32 @@ class RecommendCommandServiceTest {
         //then
         assertEquals(recommendCount, 1);
     }
+
+    @Test
+    @DisplayName("cancelRecommendToFeedByFeedId() : feed에 추천해요를 취소할 수 있습니다.")
+    void test_cancelRecommendToFeedByFeedId() {
+        //given
+        final Feed feed = Feed.from(1L);
+        final Recommend recommend = Recommend.of(1L, true, feed);
+
+        feed.increaseRecommend();
+        feed.increaseRecommend();
+        feed.increaseRecommend();
+
+        //when
+        when(feedRepository.findById(anyLong()))
+                .thenReturn(Optional.of(feed));
+
+        when(recommendRepository.findById(anyLong()))
+                .thenReturn(Optional.of(recommend));
+
+        final long recommendCount = recommendCommandService.
+                cancelRecommendToFeedByFeedId(1L, 1L, 1L);
+
+        //then
+        assertAll(
+                () -> assertEquals(recommendCount, 2),
+                () -> assertFalse(recommend.isRecommended())
+        );
+    }
 }


### PR DESCRIPTION
### 📌 PR Type

- [x]  Feature

### ✏️ Jira num

resolved(SSG): TERK-97

resolved(Team B): STR-11

### 📑Description
- 북마크 저장/취소 API 
- 추천해요 저장/취소 API

북마크와 추천해요는 사용자가 피드에 당 각 한번씩 가능합니다.

#### 북마크/추천해요 처음 누를 경우
- 북마크/추천해요 테이블에 저장, feed 테이블에 있는 각 count +1 증가

#### 북마크/추천해요를 이전에 눌렀다가 취소하고, 다시 누를 경우
- 북마크/추천해요 테이블에 account-id, feed-id를 통해 데이터를 가져온 뒤, boolean true로 변경

#### 북마크/추천해요를 삭제(취소)할 경우
- 북마크/추천해요 테이블에 account-id, feed-id를 통해 데이터를 가져온 뒤, boolean false로 변경

### ✒️ 코드 리뷰 요청 사항
이번 pr은 구현 위주입니다. 그래서 단위 테스트를 통해서 확인을 했지만 코드를 보시고 이상한 부분은 리뷰 부탁드립니다(북마크, 추천해요 로직이 매우 비슷해서 코드가 비슷합니다).
그리고 이전 pr에서 피드백 받았던 Optional 를 제대로(?) 사용해보려고 했습니다.

### ✔️ 코드 리뷰 반영 사항
